### PR TITLE
Set default stage in .pre-commit-config.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,8 @@
 default_language_version:
     python: python3.13
 
+default_stages: [pre-commit]
+
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0


### PR DESCRIPTION
The `default_stages: [pre-commit]` is requited because the pre-commit check is done twice.