### PR TITLE
Disable unittest in VS Code settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,7 +13,7 @@
     "python.testing.pytestArgs": [
         "tests/"
     ],
-    "python.testing.unittestEnabled": true,
+    "python.testing.unittestEnabled": false,
     "python.testing.pytestEnabled": true,
     "python.testing.pytestPath": "python -m pytest",
     "cSpell.language": "en",


### PR DESCRIPTION
Either `unittest` or `pytest` can be enabled.